### PR TITLE
Dispose AnimationController before its parent

### DIFF
--- a/lib/src/first_stepper/opacity_animated.dart
+++ b/lib/src/first_stepper/opacity_animated.dart
@@ -63,8 +63,8 @@ class _OpacityAnimatedState extends State<OpacityAnimated>
 
   @override
   void dispose() {
-    super.dispose();
     _animationController.dispose();
+    super.dispose();
   }
 
   @override


### PR DESCRIPTION
Otherwise this exception happens:
Exception has occurred.
FlutterError (_OpacityAnimatedState#aa454(ticker active) was disposed with an active Ticker.
_OpacityAnimatedState created a Ticker via its SingleTickerProviderStateMixin, but at the time dispose() was called on the mixin, that Ticker was still active. The Ticker must be disposed before calling super.dispose().
Tickers used by AnimationControllers should be disposed by calling dispose() on the AnimationController itself. Otherwise, the ticker will leak.
The offending ticker was:
  Ticker(created by _OpacityAnimatedState#aa454(lifecycle state: created))