### PR TITLE
Fix: Warning: Operand of null-aware operation '?.' has type 'WidgetsBinding' which excludes null.

### DIFF
--- a/lib/src/first_stepper/core/base_stepper.dart
+++ b/lib/src/first_stepper/core/base_stepper.dart
@@ -166,7 +166,7 @@ class _BaseStepperState extends State<BaseStepper> {
   @override
   Widget build(BuildContext context) {
     // Controls scrolling behavior.
-    if (!widget.scrollingDisabled) WidgetsBinding.instance.addPostFrameCallback(_afterLayout);
+    if (!widget.scrollingDisabled) WidgetsBinding.instance?.addPostFrameCallback(_afterLayout);
 
     return widget.direction == Axis.horizontal
         ? Row(


### PR DESCRIPTION
Hi there,

Hope you're well!

First of my apologies for ending up doing 2 Pull Requests, but had few issues, so wanted to quickly put as off rather then being merged. Handled the issue for `Warning: Operand of null-aware operation '?.' has type 'WidgetsBinding' which excludes null`.

Issues list:
https://github.com/imujtaba8488/package_im_stepper/issues/38
https://github.com/imujtaba8488/package_im_stepper/issues/37

Thank you for the amazing plugin, we did upgrade the needs for it to be compatible with Flutter 3, as we needed this plugin to be fixed as soon as possible, which I believe many others does need it as well!

We tested this, yet we suggest to give it a try as well 🍻 

Best regards,
Red